### PR TITLE
ci: add Google Play publish workflow

### DIFF
--- a/.github/workflows/publish-play.yml
+++ b/.github/workflows/publish-play.yml
@@ -1,0 +1,103 @@
+name: Publish to Google Play
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Play Store track to publish to'
+        required: true
+        default: 'internal'
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build signed AAB and upload to Play
+    runs-on: ubuntu-latest
+    env:
+      # Track input is only set on workflow_dispatch; default to 'internal' on tag push.
+      PLAY_TRACK: ${{ github.event.inputs.track || 'internal' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # androidGitVersion needs full history + tags to compute versionCode/versionName.
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
+
+      - name: Decode upload keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 secret is not set"
+            exit 1
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "${RUNNER_TEMP}/upload.keystore"
+          echo "ANDROID_KEY_FILE=${RUNNER_TEMP}/upload.keystore" >> "$GITHUB_ENV"
+
+      - name: Build signed release AAB
+        env:
+          ORG_GRADLE_PROJECT_ANDROID_SIGNING_KEY: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ORG_GRADLE_PROJECT_ANDROID_KEY_FILE: ${{ env.ANDROID_KEY_FILE }}
+        run: ./gradlew :app:bundleProdRelease --no-daemon --stacktrace
+
+      - name: Locate AAB and read package name
+        id: artifacts
+        run: |
+          AAB_PATH=$(find app/build/outputs/bundle/prodRelease -name '*.aab' | head -n1)
+          if [ -z "$AAB_PATH" ]; then
+            echo "::error::No AAB found under app/build/outputs/bundle/prodRelease"
+            exit 1
+          fi
+          echo "aab=$AAB_PATH" >> "$GITHUB_OUTPUT"
+
+          PACKAGE_NAME=$(./gradlew -q :app:properties \
+            | awk -F': ' '/^namespace: /{print $2; exit}')
+          if [ -z "$PACKAGE_NAME" ]; then
+            # Fallback: grep the build.gradle for namespace
+            PACKAGE_NAME=$(grep -E '^\s*namespace\s*=' app/build.gradle \
+              | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')
+          fi
+          echo "package=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+          echo "Resolved package: $PACKAGE_NAME"
+          echo "Resolved AAB:     $AAB_PATH"
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: app-prod-release.aab
+          path: ${{ steps.artifacts.outputs.aab }}
+          if-no-files-found: error
+
+      - name: Publish to Google Play
+        # No first-party Google action exists for the Play Developer API; r0adkll's
+        # action is the de-facto community standard. Pinned by tag SHA.
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ steps.artifacts.outputs.package }}
+          releaseFiles: ${{ steps.artifacts.outputs.aab }}
+          track: ${{ env.PLAY_TRACK }}
+          status: completed

--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
 # WhenApp-Android
 
 More info coming soon! For now, join us on [Discord](https://discord.gg/sJWCF6P)!
+
+## Release
+
+Releases are built and uploaded to Google Play by the
+[`Publish to Google Play`](.github/workflows/publish-play.yml) GitHub Actions
+workflow.
+
+Triggers:
+
+- **Tag push** matching `v*` (e.g. `v1.2.3`) — publishes to the `internal`
+  track by default.
+- **Manual** (`workflow_dispatch`) — choose a track from
+  `internal` / `alpha` / `beta` / `production`.
+
+The workflow checks out the repo, sets up JDK 17 + Gradle, decodes the
+upload keystore from a secret, runs `./gradlew :app:bundleProdRelease` to
+produce a signed `.aab`, then uploads it to Google Play via the Play
+Developer API.
+
+### Required repository secrets
+
+| Secret | Purpose |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | Base64-encoded upload keystore (`base64 -w0 upload.keystore`) |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore (store) password |
+| `ANDROID_KEY_ALIAS` | Key alias inside the keystore |
+| `ANDROID_KEY_PASSWORD` | Password for the key entry |
+| `PLAY_SERVICE_ACCOUNT_JSON` | Full JSON for a Google Play service account with `Release Manager` permissions |
+
+The package name is read from the `app` module's `namespace`
+(`tech.akpmakes.android.taskkeeper`).
+
+### Cutting a release
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The workflow run will build, sign, and upload to the `internal` track. To
+promote to a different track, re-run with `workflow_dispatch` and pick the
+target track, or promote via the Play Console.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,14 @@ android {
                 storePassword ANDROID_STORE_PASSWORD
             }
         }
+        releaseApp {
+            if(project.hasProperty('ANDROID_SIGNING_KEY')) {
+                keyAlias ANDROID_SIGNING_KEY
+                keyPassword ANDROID_KEY_PASSWORD
+                storeFile file(ANDROID_KEY_FILE)
+                storePassword ANDROID_STORE_PASSWORD
+            }
+        }
     }
     defaultConfig {
         applicationId "tech.akpmakes.android.taskkeeper"
@@ -51,6 +59,9 @@ android {
     }
     buildTypes {
         release {
+            if(project.hasProperty('ANDROID_SIGNING_KEY')) {
+                signingConfig signingConfigs.releaseApp
+            }
             minifyEnabled true
             shrinkResources = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds a signed AAB and uploads it to Google Play via the Play Developer API.

- **Workflow:** `.github/workflows/publish-play.yml`
- **Triggers:**
  - `push` on tags matching `v*` (publishes to `internal` by default)
  - `workflow_dispatch` with a `track` input: `internal` / `alpha` / `beta` / `production`
- **Steps:** checkout (full history for `androidGitVersion`) → JDK 17 (Temurin) → `gradle/actions/setup-gradle` → decode keystore from base64 secret → `./gradlew :app:bundleProdRelease` → upload AAB artifact → `r0adkll/upload-google-play@v1.1.5` (pinned by commit SHA)
- **Track:** configurable via `workflow_dispatch` input; defaults to `internal` on tag pushes
- **Package name:** read from the app module's `namespace` (`tech.akpmakes.android.taskkeeper`) at workflow runtime

### Action sourcing

Per the standing rule "prefer official Actions to community ones": all steps use first-party actions (`actions/checkout`, `actions/setup-java`, `gradle/actions/setup-gradle`, `actions/upload-artifact`) **except** the final upload — there is no first-party Google action for the Play Developer API. `r0adkll/upload-google-play` is the de-facto community standard and is pinned by tag SHA (`v1.1.5` → `e738b9d`).

All actions pinned to commit SHA with version comments.

### Signing config wiring

The existing `app/build.gradle` only had a debug signing config. Added a parallel `releaseApp` block (same shape, same Gradle properties — `ANDROID_SIGNING_KEY`, `ANDROID_KEY_PASSWORD`, `ANDROID_KEY_FILE`, `ANDROID_STORE_PASSWORD`) and wired it into `buildTypes.release`. All values are passed in via CI env vars (`ORG_GRADLE_PROJECT_*`); nothing is committed. Locally, builds without `ANDROID_SIGNING_KEY` set still produce an unsigned release exactly as before.

No tooling upgrades — AGP 8.12.2 / Gradle 8.13 / JDK 17 (matches what AGP 8.x requires) / Groovy DSL all preserved.

### Required secrets (configure under repo Settings → Secrets and variables → Actions)

| Secret | Purpose |
| --- | --- |
| `ANDROID_KEYSTORE_BASE64` | Base64-encoded upload keystore (`base64 -w0 upload.keystore`) |
| `ANDROID_KEYSTORE_PASSWORD` | Keystore (store) password |
| `ANDROID_KEY_ALIAS` | Key alias inside the keystore |
| `ANDROID_KEY_PASSWORD` | Password for the key entry |
| `PLAY_SERVICE_ACCOUNT_JSON` | Full JSON for a Play service account with `Release Manager` permission on this package |

> **Note:** Google Play requires the package's first AAB to be uploaded manually before the Developer API will accept uploads. After that one-time bootstrap, this workflow handles every subsequent release.

### Test plan

- [ ] Configure the five secrets above
- [ ] Manually run the workflow via `workflow_dispatch` with `track=internal` to validate the build and upload path
- [ ] Push a `v*` tag and confirm the run publishes to the internal track

### Refs

- https://github.com/r0adkll/upload-google-play
- https://developers.google.com/android-publisher
- https://github.com/gradle/actions/tree/main/setup-gradle
