### PR TITLE
ci(play): clean up workflow warnings

### DIFF
--- a/.github/workflows/publish-play.yml
+++ b/.github/workflows/publish-play.yml
@@ -30,19 +30,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # androidGitVersion needs full history + tags to compute versionCode/versionName.
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Decode upload keystore
         env:
@@ -73,6 +73,12 @@ jobs:
           fi
           echo "aab=$AAB_PATH" >> "$GITHUB_OUTPUT"
 
+          # AGP emits native-debug-symbols.zip when buildTypes.release sets
+          # ndk.debugSymbolLevel = 'FULL' (it does in app/build.gradle). Upload
+          # it alongside the AAB so Play can symbolicate native crashes.
+          SYMBOLS_PATH=$(find app/build/outputs/native-debug-symbols/prodRelease -name 'native-debug-symbols.zip' 2>/dev/null | head -n1)
+          echo "symbols=$SYMBOLS_PATH" >> "$GITHUB_OUTPUT"
+
           PACKAGE_NAME=$(./gradlew -q :app:properties \
             | awk -F': ' '/^namespace: /{print $2; exit}')
           if [ -z "$PACKAGE_NAME" ]; then
@@ -99,5 +105,6 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: ${{ steps.artifacts.outputs.package }}
           releaseFiles: ${{ steps.artifacts.outputs.aab }}
-          track: ${{ env.PLAY_TRACK }}
+          debugSymbols: ${{ steps.artifacts.outputs.symbols }}
+          tracks: ${{ env.PLAY_TRACK }}
           status: completed


### PR DESCRIPTION
Tidies three classes of warning surfaced by the first successful run ([25323773312](https://github.com/WhenApp/WhenApp-Android/actions/runs/25323773312)) plus a Play Console warning.

### 1. Node.js 20 actions deprecation

Runner warning:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout, actions/setup-java, actions/upload-artifact, gradle/actions/setup-gradle. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

Bumped pins (all by tag SHA, all official):
| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4.2.2 | v6.0.2 |
| `actions/setup-java` | v4.7.1 | v5.2.0 |
| `gradle/actions/setup-gradle` | v4.3.0 | v6.1.0 |
| `actions/upload-artifact` | v4.6.2 | (unchanged — already current) |

### 2. `track` -> `tracks` on r0adkll/upload-google-play

Action warning:
> ##[warning]WARNING!! 'track' is deprecated and will be removed in a future release. Please migrate to 'tracks'

Renamed the input. `tracks` accepts the same string for a single track, so behavior is unchanged.

### 3. Native debug symbols

Play Console warning, reported separately by the user:
> This App Bundle contains native code, and you've not uploaded debug symbols. We recommend you upload a symbol file to make your crashes and ANRs easier to analyze and debug.

`app/build.gradle` already sets `ndk.debugSymbolLevel = 'FULL'` on the `release` build type, so AGP produces `app/build/outputs/native-debug-symbols/prodRelease/native-debug-symbols.zip` automatically — we just weren't passing it to Play. Wired it through the action's `debugSymbols` input.